### PR TITLE
Rename referred symbols in ns instead of aliasing

### DIFF
--- a/src/miner/herbert.clj
+++ b/src/miner/herbert.clj
@@ -4,17 +4,11 @@
             [miner.tagged :as tag]
             [squarepeg.core :as sp]
             [miner.herbert.canonical :as canonical]
-            [miner.herbert.private :as internal :refer :all])
+            [miner.herbert.private :as internal :refer :all 
+                                   :rename {internal-reserved-ops reserved-ops, 
+                                            internal-ns->predicates ns->predicates, 
+                                            internal-default-predicates default-predicates}])
   (:import miner.tagged.TaggedValue))
-
-
-
-;; inherit some things from internal
-(def reserved-ops internal-reserved-ops)
-
-(def ns->predicates internal-ns->predicates)
-
-(def default-predicates internal-default-predicates)
 
 
 (defn constraint-fn [schema]


### PR DESCRIPTION
IMHO it's idiomatic to use the :rename option in the `ns` declaration than to create aliases via def.
